### PR TITLE
Renaming ass rule

### DIFF
--- a/fp_growth.py
+++ b/fp_growth.py
@@ -332,7 +332,7 @@ class FPNode(object):
 
 def subs(l):
     """
-    Used for assRule
+    Used for assoc_rule
     """
     assert type(l) is list
     if len(l) == 1:
@@ -342,9 +342,9 @@ def subs(l):
 
 
 # Association rules
-def assRule(freq, min_conf=0.6):
+def assoc_rule(freq, min_conf=0.6):
     """
-    This assRule must input a dict for itemset -> support rate
+    This assoc_rule must input a dict for itemset -> support rate
     And also can customize your minimum confidence
     """
     assert type(freq) is dict
@@ -428,7 +428,7 @@ if __name__ == "__main__":
         for itemset, support in result:
             print(str(itemset) + " " + str(support))
     if options.find == "rule":
-        rules = assRule(res_for_rul, options.minconf)
+        rules = assoc_rule(res_for_rul, options.minconf)
         for ru in rules:
             print(str(ru["from"]) + " -> " + str(ru["to"]))
             print("support = " + str(ru["sup"]) + "confidence = " + str(ru["conf"]))

--- a/fp_growth.py
+++ b/fp_growth.py
@@ -33,7 +33,7 @@ def find_frequent_itemsets(transactions, minimum_support, include_support=False)
     """
     items = defaultdict(lambda: 0)  # mapping from items to their supports
 
-    # if useing support rate instead of support count
+    # if using support rate instead of support count
     if 0 < minimum_support <= 1:
         minimum_support = minimum_support * len(transactions)
 
@@ -317,7 +317,7 @@ class FPNode(object):
     @property
     def children(self):
         """The nodes that are children of this node."""
-        return tuple(self._children.itervalues())
+        return tuple(self._children.values())
 
     def inspect(self, depth=0):
         print(("  " * depth) + repr(self))
@@ -431,4 +431,4 @@ if __name__ == "__main__":
         rules = assRule(res_for_rul, options.minconf)
         for ru in rules:
             print(str(ru["from"]) + " -> " + str(ru["to"]))
-            print("support = " + str(ru["sup"]) + "confindence = " + str(ru["conf"]))
+            print("support = " + str(ru["sup"]) + "confidence = " + str(ru["conf"]))

--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ Testing code for the FP-growth implementation.
 
 import unittest
 import fp_growth
-from itertools import izip
+
 
 class NodeTester(object):
     def __init__(self, case, node):
@@ -24,8 +24,8 @@ class NodeTester(object):
 
     def count(self, count):
         self.case.assertEqual(self.node.count, count,
-            'expected count to be %d; instead it was %d' %
-            (count, self.node.count))
+                              'expected count to be %d; instead it was %d' %
+                              (count, self.node.count))
         return self
 
     def leaf(self):
@@ -45,9 +45,9 @@ class TreeTestCase(unittest.TestCase):
         actual = list(actual)
         self.assertEqual(len(expected), len(actual))
 
-        for items, path in izip(expected, actual):
+        for items, path in zip(expected, actual):
             self.assertEqual(len(items), len(path))
-            for item, node in izip(items, path):
+            for item, node in zip(items, path):
                 self.assertEqual(item, node.item)
 
 
@@ -72,10 +72,10 @@ class InsertionTests(TreeTestCase):
         b.child('d', 1).child('e', 1)
 
     def testNumeric(self):
-        self.tree.add([1,2,3])
-        self.tree.add([1,2,4])
-        self.root.child(1,2).child(2,2).child(3,1)
-        self.root.child(1,2).child(2,2).child(4,1)
+        self.tree.add([1, 2, 3])
+        self.tree.add([1, 2, 4])
+        self.root.child(1, 2).child(2, 2).child(3, 1)
+        self.root.child(1, 2).child(2, 2).child(4, 1)
 
 
 class RouteTests(TreeTestCase):
@@ -128,7 +128,7 @@ class ConditionalTreeTests(TreeTestCase):
         root = NodeTester(self, ct.root)
 
         a = root.child('a', 2)
-        a.child('b', 1).child('d',1).leaf()
+        a.child('b', 1).child('d', 1).leaf()
         self.assertEqual(2, len(a.node.children))
 
     def testPruning(self):
@@ -141,7 +141,7 @@ class ConditionalTreeTests(TreeTestCase):
         paths = list(self.tree.prefix_paths('c'))
         ct = fp_growth.conditional_tree_from_paths(paths)
         root = NodeTester(self, ct.root)
-        root.child('a', 2).child('b',1).child('c',1).leaf()
+        root.child('a', 2).child('b', 1).child('c', 1).leaf()
         self.assertEqual(2, len(root.node.children))
 
     def testSupport(self):
@@ -152,10 +152,10 @@ class ConditionalTreeTests(TreeTestCase):
         self.tree.add('abd')
         paths = list(self.tree.prefix_paths('d'))
         ct = fp_growth.conditional_tree_from_paths(paths)
-        root = NodeTester(self,ct.root)
-        a = root.child('a',2)
-        b = a.child('b',2)
-        c = b.child('c',1)
+        root = NodeTester(self, ct.root)
+        a = root.child('a', 2)
+        b = a.child('b', 2)
+        c = b.child('c', 1)
 
 
 class FrequentSetTests(unittest.TestCase):
@@ -164,8 +164,9 @@ class FrequentSetTests(unittest.TestCase):
         transactions = [line.split(',') for line in raw.split(';')]
 
         itemsets = list(fp_growth.find_frequent_itemsets(transactions, 2))
-        self.assertEqual([['25'], ['52', '25'], ['274'], ['71'], ['52']],
-            itemsets)
+        self.assertEqual(sorted([['25'], ['52', '25'], ['274'], ['71'], ['52']]),
+                         sorted(itemsets))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
According to [PEP 8](https://www.python.org/dev/peps/pep-0008/) all Python functions should be named using only lowercase letters.
The assRule (now assoc_rule) function did not comply with this so I changed it.